### PR TITLE
Made ammo automatically pick up rather than prompting to press E

### DIFF
--- a/Source/Survival/AmmoPickup.cpp
+++ b/Source/Survival/AmmoPickup.cpp
@@ -39,4 +39,5 @@ void AAmmoPickup::BeginPlay()
 {
 	Super::BeginPlay();
 	SetPickupItemName(BulletName);
+    SetPickupOnOverlap(true);
 }

--- a/Source/Survival/PickupBase.cpp
+++ b/Source/Survival/PickupBase.cpp
@@ -9,7 +9,9 @@ APickupBase::APickupBase()
 
 }
 
-
+bool APickupBase::ShouldPickupOnOverlap() const {
+	return PickupOnOverlap;
+}
 
 void APickupBase::SetPickupOnOverlap(bool Enable)
 {

--- a/Source/Survival/PickupBase.cpp
+++ b/Source/Survival/PickupBase.cpp
@@ -2,10 +2,23 @@
 
 
 #include "Survival/PickupBase.h"
+#include "Components/SphereComponent.h"
+#include "Survival/SurvivalCharacter.h"
 
 APickupBase::APickupBase()
 {
 	PrimaryActorTick.bCanEverTick = true;
+
+	PickupSphere = CreateDefaultSubobject<USphereComponent>(TEXT("PickupSphere"));
+	SetRootComponent(PickupSphere);
+
+	PickupSphere->InitSphereRadius(50.f);
+	PickupSphere->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+	PickupSphere->SetCollisionObjectType(ECC_WorldDynamic);
+	PickupSphere->SetCollisionResponseToAllChannels(ECR_Ignore);
+	PickupSphere->SetCollisionResponseToChannel(ECC_Pawn, ECR_Overlap);
+
+	PickupSphere->OnComponentBeginOverlap.AddDynamic(this, &APickupBase::OnPickupSphereOverlap);
 
 }
 
@@ -16,6 +29,28 @@ bool APickupBase::ShouldPickupOnOverlap() const {
 void APickupBase::SetPickupOnOverlap(bool Enable)
 {
 	PickupOnOverlap = Enable;
+}
+
+void APickupBase::OnPickupSphereOverlap(
+	UPrimitiveComponent* OverlappedComponent,
+	AActor* OtherActor,
+	UPrimitiveComponent* OtherComp,
+	int32 OtherBodyIndex,
+	bool bFromSweep,
+	const FHitResult& SweepResult)
+{
+	ASurvivalCharacter* PickupCharacter = Cast<ASurvivalCharacter>(OtherActor);
+	if (!PickupCharacter)
+	{
+		return;
+	}
+
+	if (!ShouldPickupOnOverlap())
+	{
+		return;
+	}
+
+	OnPlayerInteract(PickupCharacter);
 }
 
 void APickupBase::SetPickupItemName(const FString& Name)

--- a/Source/Survival/PickupBase.h
+++ b/Source/Survival/PickupBase.h
@@ -15,6 +15,9 @@ public:
 	APickupBase();
 	FString GetPickupInteractionPrompt() const;
 
+	// A getter so that other classes can check if a pickup should activate on overlap
+	bool ShouldPickupOnOverlap() const;
+
 
 	virtual void OnPlayerInteract(ASurvivalCharacter* Interactor) {};
 protected:

--- a/Source/Survival/PickupBase.h
+++ b/Source/Survival/PickupBase.h
@@ -5,6 +5,9 @@
 #include "PickupBase.generated.h"
 
 class ASurvivalCharacter;
+class USphereComponent;
+class UPrimitiveComponent;
+struct FHitResult;
 
 UCLASS()
 class SURVIVAL_API APickupBase : public AActor
@@ -24,9 +27,21 @@ protected:
 	void SetPickupOnOverlap(bool Enable);
 	void SetPickupItemName(const FString& Name);
 
+	UFUNCTION()
+	void OnPickupSphereOverlap(
+		UPrimitiveComponent* OverlappedComponent,
+		AActor* OtherActor,
+		UPrimitiveComponent* OtherComp,
+		int32 OtherBodyIndex,
+		bool bFromSweep,
+		const FHitResult& SweepResult
+	);
+
 
 private:
 
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Collision", meta = (AllowPrivateAccess = "true"))
+	USphereComponent* PickupSphere;
 
 
 	// Set this if the user does not have to press "E" on the object to pick it up

--- a/Source/Survival/SurvivalWeaponComponent.cpp
+++ b/Source/Survival/SurvivalWeaponComponent.cpp
@@ -11,7 +11,8 @@
 #include "Animation/AnimInstance.h"
 #include "Engine/LocalPlayer.h"
 #include "Engine/World.h"
-#include "Components/SphereComponent.h"
+#include "SurvivalPickUpComponent.h"
+
 // Sets default values for this component's properties
 ASurvivalWeaponActor::ASurvivalWeaponActor() 
 	: APickupBase()
@@ -21,13 +22,15 @@ ASurvivalWeaponActor::ASurvivalWeaponActor()
 	Mesh = CreateDefaultSubobject<USkeletalMeshComponent>(TEXT("CharacterMesh1P"));
 	SetRootComponent(Mesh);
 
-	PickupSphere = CreateDefaultSubobject<USphereComponent>(TEXT("PickupSphere"));
-	PickupSphere->InitSphereRadius(50.f);
-	PickupSphere->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
-	PickupSphere->SetCollisionObjectType(ECC_WorldDynamic);
-	PickupSphere->SetCollisionResponseToAllChannels(ECR_Ignore);
-	PickupSphere->SetCollisionResponseToChannel(ECC_Visibility, ECR_Block);
-	PickupSphere->SetupAttachment(Mesh);
+
+	// PickupSphere became PickupComponent so that pickup overlap is handled by SurvivalPickUpComponent
+	PickupComponent = CreateDefaultSubobject<USurvivalPickUpComponent>(TEXT("PickupComponent"));
+	PickupComponent->InitSphereRadius(50.f);
+	PickupComponent->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+	PickupComponent->SetCollisionObjectType(ECC_WorldDynamic);
+	PickupComponent->SetCollisionResponseToAllChannels(ECR_Ignore);
+	PickupComponent->SetCollisionResponseToChannel(ECC_Pawn, ECR_Overlap);
+	PickupComponent->SetupAttachment(Mesh);
 
 
 }
@@ -152,7 +155,7 @@ void ASurvivalWeaponActor::EnableSimulation()
 	Mesh->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
 	Mesh->SetSimulatePhysics(true);
 
-	PickupSphere->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+	PickupComponent->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
 
 }
 
@@ -175,7 +178,7 @@ void ASurvivalWeaponActor::DisableSimulation()
 {
 	Mesh->SetSimulatePhysics(false);
 	Mesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
-	PickupSphere->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	PickupComponent->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 
 }
 
@@ -352,5 +355,19 @@ void ASurvivalWeaponActor::BeginPlay()
 	SetPickupItemName(WeaponName);
 
 	BulletsLeftInMagazine = MagazineSize;
+
+	if (PickupComponent) {
+		PickupComponent->OnPickUp.AddDynamic(this, &ASurvivalWeaponActor::OnPickupOverlap);
+	}
 }
+
+void ASurvivalWeaponActor::OnPickupOverlap(ASurvivalCharacter* PickupCharacter) {
+
+	if (PickupCharacter) {
+		OnPlayerInteract(PickupCharacter);
+	}
+
+}
+
+
 

--- a/Source/Survival/SurvivalWeaponComponent.cpp
+++ b/Source/Survival/SurvivalWeaponComponent.cpp
@@ -11,8 +11,7 @@
 #include "Animation/AnimInstance.h"
 #include "Engine/LocalPlayer.h"
 #include "Engine/World.h"
-#include "SurvivalPickUpComponent.h"
-
+#include "Components/SphereComponent.h"
 // Sets default values for this component's properties
 ASurvivalWeaponActor::ASurvivalWeaponActor() 
 	: APickupBase()
@@ -21,18 +20,6 @@ ASurvivalWeaponActor::ASurvivalWeaponActor()
 	bIsReloading = false;
 	Mesh = CreateDefaultSubobject<USkeletalMeshComponent>(TEXT("CharacterMesh1P"));
 	SetRootComponent(Mesh);
-
-
-	// PickupSphere became PickupComponent so that pickup overlap is handled by SurvivalPickUpComponent
-	PickupComponent = CreateDefaultSubobject<USurvivalPickUpComponent>(TEXT("PickupComponent"));
-	PickupComponent->InitSphereRadius(50.f);
-	PickupComponent->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
-	PickupComponent->SetCollisionObjectType(ECC_WorldDynamic);
-	PickupComponent->SetCollisionResponseToAllChannels(ECR_Ignore);
-	PickupComponent->SetCollisionResponseToChannel(ECC_Pawn, ECR_Overlap);
-	PickupComponent->SetupAttachment(Mesh);
-
-
 }
 
 
@@ -155,7 +142,7 @@ void ASurvivalWeaponActor::EnableSimulation()
 	Mesh->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
 	Mesh->SetSimulatePhysics(true);
 
-	PickupComponent->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+	
 
 }
 
@@ -178,7 +165,6 @@ void ASurvivalWeaponActor::DisableSimulation()
 {
 	Mesh->SetSimulatePhysics(false);
 	Mesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
-	PickupComponent->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 
 }
 
@@ -355,19 +341,5 @@ void ASurvivalWeaponActor::BeginPlay()
 	SetPickupItemName(WeaponName);
 
 	BulletsLeftInMagazine = MagazineSize;
-
-	if (PickupComponent) {
-		PickupComponent->OnPickUp.AddDynamic(this, &ASurvivalWeaponActor::OnPickupOverlap);
-	}
 }
-
-void ASurvivalWeaponActor::OnPickupOverlap(ASurvivalCharacter* PickupCharacter) {
-
-	if (PickupCharacter) {
-		OnPlayerInteract(PickupCharacter);
-	}
-
-}
-
-
 

--- a/Source/Survival/SurvivalWeaponComponent.h
+++ b/Source/Survival/SurvivalWeaponComponent.h
@@ -10,7 +10,7 @@
 
 #include "SurvivalWeaponComponent.generated.h"
 class ASurvivalCharacter;
-class USphereComponent;
+class USurvivalPickUpComponent;
 class AAmmoPickup;
 
 UCLASS(Blueprintable, BlueprintType, ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
@@ -21,7 +21,7 @@ class SURVIVAL_API ASurvivalWeaponActor : public APickupBase
 public:
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Collision")
-	USphereComponent* PickupSphere;
+	USurvivalPickUpComponent* PickupComponent;
 
 	/** Projectile class to spawn */
 	UPROPERTY(EditDefaultsOnly, Category=Projectile)
@@ -119,6 +119,9 @@ public:
 	virtual void OnPlayerInteract(ASurvivalCharacter* Interactor) override;
 
 protected:
+
+	UFUNCTION()
+	void OnPickupOverlap(ASurvivalCharacter* PickupCharacter);
 	UFUNCTION()
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 

--- a/Source/Survival/SurvivalWeaponComponent.h
+++ b/Source/Survival/SurvivalWeaponComponent.h
@@ -10,7 +10,7 @@
 
 #include "SurvivalWeaponComponent.generated.h"
 class ASurvivalCharacter;
-class USurvivalPickUpComponent;
+
 class AAmmoPickup;
 
 UCLASS(Blueprintable, BlueprintType, ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
@@ -19,9 +19,6 @@ class SURVIVAL_API ASurvivalWeaponActor : public APickupBase
 	GENERATED_BODY()
 
 public:
-
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Collision")
-	USurvivalPickUpComponent* PickupComponent;
 
 	/** Projectile class to spawn */
 	UPROPERTY(EditDefaultsOnly, Category=Projectile)
@@ -119,9 +116,6 @@ public:
 	virtual void OnPlayerInteract(ASurvivalCharacter* Interactor) override;
 
 protected:
-
-	UFUNCTION()
-	void OnPickupOverlap(ASurvivalCharacter* PickupCharacter);
 	UFUNCTION()
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 


### PR DESCRIPTION
Changes:
- Replaced PickupSphere with PickupComponent
- Used USurvivalPickUpComponent for overlap detection
- Bound OnPickUp to call OnPlayerInteract
- Updated EnableSimulation/DisableSimulation to use the new component

The build was successful after the changes, and the game runs, but I was unable to test the behavior in game due to a GPU issue with my laptop that was causing crashes.